### PR TITLE
FIX: PurgeObseleteStaticCacheTask shouldn't clear out index.php or index.html

### DIFF
--- a/code/tasks/PurgeObseleteStaticCacheTask.php
+++ b/code/tasks/PurgeObseleteStaticCacheTask.php
@@ -82,7 +82,7 @@ class PurgeObseleteStaticCacheTask extends BuildTask {
 			}
 
 			// Handle homepage special case
-			if($file_relative == 'index.html') $urlpath = '';
+			if($file_relative == 'index.html' || $file_relative == 'index.php') $urlpath = '';
 
 			// Exclude files that do not end in the file extension specified for FilesystemPublisher
 			$length = strlen('.' . $fileext);
@@ -131,7 +131,7 @@ class PurgeObseleteStaticCacheTask extends BuildTask {
 				$absCacheFilePath = $directory . '/' . $cacheFilePath;
 				
 				if(file_exists($absCacheFilePath)){
-					self::msg($actionStr.': '.$file_relative);
+					self::msg(sprintf('%s: %s', $actionStr, $absCacheFilePath));
 					if(!$dry){
 						unlink($absCacheFilePath);
 					}


### PR DESCRIPTION
FIX: `PurgeObseleteStaticCacheTask` shouldn't clear out `index.php` or `index.html`

Otherwise, it purges the homepage (because `index.php` is the relative filename used on some servers).

Also fixed an issue with the logging, previously it would log:

```
Deleted: index.php
Deleted: index.php
```

Now it will log the full paths to the files being purged:

```
Deleted: /path/to/cacheroot/index.php
Deleted: /path/to/cacheroot/index.stale.html
```
